### PR TITLE
Refactor withParams

### DIFF
--- a/src/common/getDisplayName.js
+++ b/src/common/getDisplayName.js
@@ -1,0 +1,2 @@
+export default WrappedComponent =>
+  WrappedComponent.displayName || WrappedComponent.name || "Component"

--- a/src/withParams/README.md
+++ b/src/withParams/README.md
@@ -10,7 +10,7 @@ This HOC is useful when you need to control any state of the page using the quer
 ### Method
 
 ```js
-this.props.updateParams({ name: string, value: string, resetPage?: boolean }) => void
+this.props.updateParams(({ [queryName]: value }: Object));
 ```
 
 ### Data
@@ -25,19 +25,17 @@ const { ...allQueries } = this.props.params;
 import React, { Component } from "react";
 import { withParams } from "@significa/toolbox";
 
-import objEqual from "deep-equal";
-
 class App extends Component {
   componentDidUpdate(prevProps) {
     const { params } = this.props;
 
-    if (!objEqual(prevProps.params, params)) {
+    if (prevProps.params.page !== params.page)) {
       this.actionFetch(params);
     }
   }
 
   handlePageChange = value => {
-    this.props.updateParams({ name: "page", value });
+    this.props.updateParams({ "page", value, status: "filtered" });
   };
 
   render() {
@@ -48,6 +46,7 @@ class App extends Component {
 }
 
 const ParamsWithParams = withParams({
+  status: "all",
   page: 1
 });
 

--- a/src/withParams/index.js
+++ b/src/withParams/index.js
@@ -1,76 +1,80 @@
-import React, { PureComponent } from "react"
-import queryString from "qs"
-import objEqual from "deep-equal"
+import React, { PureComponent } from "react";
+import queryString from "qs";
+import objEqual from "deep-equal";
 
-import getDisplayName from "../common/getDisplayName"
+import getDisplayName from "../common/getDisplayName";
 
 export default initialQuery => WrappedComponent => {
   if (!initialQuery) {
-    throw new Error("withParams requires an initial query.")
+    throw new Error("withParams requires an initial query.");
   }
 
   return class hocComponent extends PureComponent {
-    static displayName = `withParams(${getDisplayName(WrappedComponent)})`
+    static displayName = `withParams(${getDisplayName(WrappedComponent)})`;
 
     componentDidMount() {
-      this.setInitialParams()
+      this.setInitialParams();
     }
 
     componentDidUpdate() {
-      const { history } = this.props
+      const { history } = this.props;
 
       if (!history.location.search) {
-        this.setInitialParams()
+        this.setInitialParams();
       }
     }
 
     setInitialParams = () => {
-      const { history } = this.props
+      const { history } = this.props;
 
-      const currentParams = this.getCurrentSearch()
+      const currentParams = this.getCurrentSearch();
       const objSearch = {
         ...initialQuery,
         ...currentParams
-      }
-      const strSearch = queryString.stringify(objSearch)
+      };
+      const strSearch = queryString.stringify(objSearch);
       const searchObj = queryString.parse(history.location.search, {
         ignoreQueryPrefix: true
-      })
+      });
 
       if (!objEqual(searchObj, objSearch)) {
         history.replace({
           search: strSearch
-        })
+        });
       }
-    }
+    };
 
     getCurrentSearch = () => {
-      const { history } = this.props
-      const { search } = history.location
+      const { history } = this.props;
+      const { search } = history.location;
 
-      return queryString.parse(search, { ignoreQueryPrefix: true })
-    }
+      return queryString.parse(search, { ignoreQueryPrefix: true });
+    };
 
     updateParams = newParams => {
-      const { history } = this.props
+      const { history } = this.props;
+      const strSearch = queryString.stringify({
+        ...this.getCurrentSearch(),
+        ...newParams
+      });
 
       return history.replace({
         ...history.location,
-        search: queryString.stringify(newParams)
-      })
-    }
+        search: strSearch
+      });
+    };
 
     render() {
-      const { history } = this.props
-      const searchStr = history.location.search
-      const params = queryString.parse(searchStr, { ignoreQueryPrefix: true })
+      const { history } = this.props;
+      const searchStr = history.location.search;
+      const params = queryString.parse(searchStr, { ignoreQueryPrefix: true });
       return (
         <WrappedComponent
           params={params}
           updateParams={this.updateParams}
           {...this.props}
         />
-      )
+      );
     }
-  }
-}
+  };
+};

--- a/src/withParams/index.js
+++ b/src/withParams/index.js
@@ -2,13 +2,12 @@ import React, { PureComponent } from "react"
 import queryString from "qs"
 import objEqual from "deep-equal"
 
-const getDisplayName = WrappedComponent =>
-  WrappedComponent.displayName || WrappedComponent.name || "Component"
+import getDisplayName from "../common/getDisplayName"
 
 export default initialQuery => WrappedComponent => {
-  if (!initialQuery)
-    return () =>
-      Error("You should pass an initial query into the withParams hoc.")
+  if (!initialQuery) {
+    throw new Error("withParams requires an initial query.")
+  }
 
   return class hocComponent extends PureComponent {
     static displayName = `withParams(${getDisplayName(WrappedComponent)})`
@@ -28,10 +27,10 @@ export default initialQuery => WrappedComponent => {
     setInitialParams = () => {
       const { history } = this.props
 
-      const currentParms = this.getCurrentSearch()
+      const currentParams = this.getCurrentSearch()
       const objSearch = {
         ...initialQuery,
-        ...currentParms
+        ...currentParams
       }
       const strSearch = queryString.stringify(objSearch)
       const searchObj = queryString.parse(history.location.search, {
@@ -52,18 +51,12 @@ export default initialQuery => WrappedComponent => {
       return queryString.parse(search, { ignoreQueryPrefix: true })
     }
 
-    updateParams = ({ name, value, resetPage = false }) => {
+    updateParams = newParams => {
       const { history } = this.props
-
-      const newParam = { [name]: value }
-      const currentParms = resetPage
-        ? { ...this.getCurrentSearch(), page: 1 }
-        : this.getCurrentSearch()
-      const strSearch = queryString.stringify({ ...currentParms, ...newParam })
 
       return history.replace({
         ...history.location,
-        search: strSearch
+        search: queryString.stringify(newParams)
       })
     }
 


### PR DESCRIPTION
@danilowoz this is just a suggestion.

- Moving generic functions to a `common` folder to be used by another component
- Shouldn't we immediately throw when there's no initialParams? Can revert if needed.

And the most drastic change is in the `updateParams` method.
I think it would be better to accept the whole object instead of expecting specific arguments on whether to reset the page or not.
This way we're giving more control to the user:

Instead of
```jsx
this.props.updateParams({ name: "search", value, resetPage: true })
```
we would simply
```jsx
this.props.updateParams({ ...this.props.params, search: value, page: 1 })
```
which, IMO, is more predictable.

It also allows us to update more than one param